### PR TITLE
Keep cursor at the same position after deleting from the list

### DIFF
--- a/dogears.el
+++ b/dogears.el
@@ -426,9 +426,9 @@ Compares against modes in `dogears-ignore-modes'."
   (interactive)
   (let ((place (tabulated-list-get-id)))
     (setf dogears-list (cl-delete place dogears-list)))
-  (let ((this (point)))
+  (let ((pos (point)))
     (tabulated-list-revert)
-    (goto-char this)))
+    (goto-char pos)))
 
 ;;;###autoload
 (defun dogears-list ()


### PR DESCRIPTION
Hello Adam, thank you for the package (and for many others), I found it more clean and usable than any other similar packages I tried (gum road, better-jumper).

What I found annoying is when deleting an item from the list the cursor goes to the top, so this PR tries to address this problem. I'm new to Emacs Lisp, so the implementation can be not good enough.