### PR TITLE
Fix dogears-back and dogears-go doesn't work as expected

### DIFF
--- a/dogears.el
+++ b/dogears.el
@@ -255,7 +255,7 @@ context.  PLACE should be a bookmark record."
                       (choice (completing-read "Place: " collection nil t)))
                  (list (alist-get choice collection nil nil #'equal))))
   (or (ignore-errors
-        (bookmark-jump place))
+        (bookmark-jump place) t)
       (when-let ((buffer (map-elt (cdr place) 'buffer)))
         (when (stringp buffer)
           (setf buffer (get-buffer buffer)))


### PR DESCRIPTION
It seems that (when-let ...) not very necessary.
1. The ignore-errors says "Execute BODY; if an error occurs, return nil." but it is normal for (bookmark-jump place) to return nil.
2. The bookmark-jump can switch buffer by itself, so manually switch-to-buffer is unnecessary.
3. The (when-let ...) only switches buffer, but it does not update the point.

Detail see https://github.com/alphapapa/dogears.el/issues/25