### PR TITLE
Fix sorting in dogears-go using completion properties

### DIFF
--- a/dogears.el
+++ b/dogears.el
@@ -256,7 +256,7 @@ context.  PLACE should be a bookmark record."
                                                (lambda (string predicate action)
                                                  (if (eq action 'metadata)
                                                      `(metadata (display-sort-function . ,#'identity)
-                                                                (cycle-sort-function . ,#'identiry))
+                                                                (cycle-sort-function . ,#'identity))
                                                    (complete-with-action action collection string predicate)))
                                                nil
                                                t)))

--- a/dogears.el
+++ b/dogears.el
@@ -252,7 +252,14 @@ context.  PLACE should be a bookmark record."
                                                              (dogears--format-record place))
                                            collect (cons key place)))
                       ;; TODO: Disable completion sorting (so they're always in order). 
-                      (choice (completing-read "Place: " collection nil t)))
+                      (choice (completing-read "Place: "
+                                               (lambda (string predicate action)
+                                                 (if (eq action 'metadata)
+                                                     `(metadata (display-sort-function . ,#'identity)
+                                                                (cycle-sort-function . ,#'identiry))
+                                                   (complete-with-action action collection string predicate)))
+                                               nil
+                                               t)))
                  (list (alist-get choice collection nil nil #'equal))))
   (or (ignore-errors
         (bookmark-jump place))


### PR DESCRIPTION
Not all completion frameworks sort collections in order by default. In Vertico (for example), `vertico-sort-function` is used by default when the completion table does not specify a sort function (and `vertico-sort-override-function` is nil).

This is fixed in this pull request by replacing the collection used by `dogears-go` with a completion table that sets the sort function using completion properties.